### PR TITLE
feat: implement advocates repository and base repository structure

### DIFF
--- a/src/repositories/advocates.ts
+++ b/src/repositories/advocates.ts
@@ -1,0 +1,64 @@
+import { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import BaseRepository from './base';
+import { eq, sql, SQL } from 'drizzle-orm';
+import { db } from '@/lib';
+import { advocates, advocatesToSpecialities, specialties } from '@/db/schema';
+import { TAdvocates, TAdvocatesWithSpecialities } from '@/types';
+
+class AdvocatesRepository extends BaseRepository<TAdvocates> {
+  constructor(db: NodePgDatabase) {
+    super(db);
+  }
+
+  async findAll(where?: SQL): Promise<TAdvocates[]> {
+    try {
+      const query = this.db.select().from(advocates).$dynamic();
+      if (where) {
+        query.where(where);
+      }
+
+      return query;
+    } catch (e) {
+      throw e;
+    }
+  }
+
+  async findAllWithSpecialities(
+    where?: SQL,
+  ): Promise<TAdvocatesWithSpecialities[]> {
+    try {
+      const query = this.db
+        .select({
+          id: advocates.id,
+          firstName: advocates.firstName,
+          lastName: advocates.lastName,
+          city: advocates.city,
+          degree: advocates.degree,
+          yearsOfExperience: advocates.yearsOfExperience,
+          phoneNumber: advocates.phoneNumber,
+          createdAt: advocates.createdAt,
+          specialties: sql`COALESCE(json_agg(json_build_object('id', ${specialties.id}, 'name', ${specialties.name})), '[]')`,
+        })
+        .from(advocates)
+        .leftJoin(
+          advocatesToSpecialities,
+          eq(advocates.id, advocatesToSpecialities.advocatesId),
+        )
+        .leftJoin(
+          specialties,
+          eq(advocatesToSpecialities.specialtyId, specialties.id),
+        )
+        .$dynamic();
+
+      if (where) {
+        query.where(where);
+      }
+
+      return (await query) as unknown as TAdvocatesWithSpecialities[];
+    } catch (e) {
+      throw e;
+    }
+  }
+}
+
+export const advocatesRepository = new AdvocatesRepository(db);

--- a/src/repositories/base.ts
+++ b/src/repositories/base.ts
@@ -1,0 +1,32 @@
+import { SQL } from 'drizzle-orm';
+import { NodePgDatabase } from 'drizzle-orm/node-postgres';
+
+abstract class BaseRepository<T> {
+  readonly db: NodePgDatabase;
+
+  constructor(db: NodePgDatabase) {
+    this.db = db;
+  }
+
+  findAll(where?: SQL): Promise<T[]> {
+    throw new Error('Method not implemented.');
+  }
+
+  findById(id: number): Promise<T | null> {
+    throw new Error('Method not implemented.');
+  }
+
+  create(data: Partial<T>): Promise<T> {
+    throw new Error('Method not implemented.');
+  }
+
+  update(id: number, data: Partial<T>) {
+    throw new Error('Method not implemented.');
+  }
+
+  delete(id: number): Promise<boolean> {
+    throw new Error('Method not implemented.');
+  }
+}
+
+export default BaseRepository;

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -1,0 +1,2 @@
+export * from './base';
+export * from './advocates';

--- a/src/types/advocates.ts
+++ b/src/types/advocates.ts
@@ -1,0 +1,8 @@
+import { advocates } from '@/db/schema';
+import { TSpecialities } from './specialities';
+
+export type TAdvocates = typeof advocates.$inferSelect;
+
+export type TAdvocatesWithSpecialities = TAdvocates & {
+  specialities: TSpecialities[];
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './advocates';
+export * from './specialities';

--- a/src/types/specialities.ts
+++ b/src/types/specialities.ts
@@ -1,0 +1,3 @@
+import { specialties } from '@/db/schema';
+
+export type TSpecialities = typeof specialties.$inferSelect;


### PR DESCRIPTION
### Why this change? 

To improve the scalability and maintainability of the project, I introduced an abstract BaseRepository class, and implemented an AdvocatesRepository. This change separates business logic from the data layer, allowing for better organization and easier future expansion.

### Why This is an Improvement

- Scalability: Separates data layer from business logic, making the project more scalable.
- Maintainability: Clearer structure with reusable repository logic.
- Separation of Concerns: Business logic and data access are now properly separated for cleaner code.